### PR TITLE
Switch sdk to a serviced tag

### DIFF
--- a/CustomerApi/CustomerApi/Dockerfile
+++ b/CustomerApi/CustomerApi/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["CustomerApi/CustomerApi.csproj", "CustomerApi/"]
 COPY ["CustomerApi.Data/CustomerApi.Data.csproj", "CustomerApi.Data/"]

--- a/CustomerApi/CustomerApi/Dockerfile.Build
+++ b/CustomerApi/CustomerApi/Dockerfile.Build
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["CustomerApi/CustomerApi.csproj", "CustomerApi/"]
 COPY ["CustomerApi.Data/CustomerApi.Data.csproj", "CustomerApi.Data/"]

--- a/CustomerApi/CustomerApi/Dockerfile.develop
+++ b/CustomerApi/CustomerApi/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV ASPNETCORE_URLS=http://+:80

--- a/OrderApi/OrderApi/Dockerfile
+++ b/OrderApi/OrderApi/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["OrderApi/OrderApi.csproj", "OrderApi/"]
 COPY ["OrderApi.Data/OrderApi.Data.csproj", "OrderApi.Data/"]

--- a/OrderApi/OrderApi/Dockerfile.Build
+++ b/OrderApi/OrderApi/Dockerfile.Build
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["OrderApi/OrderApi.csproj", "OrderApi/"]
 COPY ["OrderApi.Data/OrderApi.Data.csproj", "OrderApi.Data/"]

--- a/OrderApi/OrderApi/Dockerfile.develop
+++ b/OrderApi/OrderApi/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 ARG BUILD_CONFIGURATION=Debug
 ENV ASPNETCORE_ENVIRONMENT=Development
 ENV ASPNETCORE_URLS=http://+:80


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?